### PR TITLE
CFEP-18: Remove static libraries from main build

### DIFF
--- a/.ci_support/win_64_target_platformwin-64.yaml
+++ b/.ci_support/win_64_target_platformwin-64.yaml
@@ -6,5 +6,3 @@ channel_targets:
 - conda-forge main
 target_platform:
 - win-64
-vc:
-- '14'

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-lz4--c-green.svg)](https://anaconda.org/conda-forge/lz4-c) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/lz4-c.svg)](https://anaconda.org/conda-forge/lz4-c) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/lz4-c.svg)](https://anaconda.org/conda-forge/lz4-c) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/lz4-c.svg)](https://anaconda.org/conda-forge/lz4-c) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-lz4--c--static-green.svg)](https://anaconda.org/conda-forge/lz4-c-static) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/lz4-c-static.svg)](https://anaconda.org/conda-forge/lz4-c-static) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/lz4-c-static.svg)](https://anaconda.org/conda-forge/lz4-c-static) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/lz4-c-static.svg)](https://anaconda.org/conda-forge/lz4-c-static) |
 
 Installing lz4-c
 ================
@@ -100,10 +101,10 @@ Installing `lz4-c` from the `conda-forge` channel can be achieved by adding `con
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `lz4-c` can be installed with:
+Once the `conda-forge` channel has been enabled, `lz4-c, lz4-c-static` can be installed with:
 
 ```
-conda install lz4-c
+conda install lz4-c lz4-c-static
 ```
 
 It is possible to list all of the versions of `lz4-c` available on your platform with:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -55,8 +55,6 @@ COPY %SRC_DIR%\lib\lz4hc.h %LIBRARY_INC%
 if errorlevel 1 exit 1
 COPY %SRC_DIR%\lib\lz4frame.h %LIBRARY_INC%
 if errorlevel 1 exit 1
-COPY %BUILD_DIR%\liblz4_static.lib %LIBRARY_LIB%
-if errorlevel 1 exit 1
 COPY %BUILD_DIR%\liblz4.dll %LIBRARY_BIN%
 if errorlevel 1 exit 1
 COPY %BUILD_DIR%\liblz4.lib %LIBRARY_LIB%

--- a/recipe/bld_static.bat
+++ b/recipe/bld_static.bat
@@ -1,0 +1,3 @@
+COPY %BUILD_DIR%\liblz4_static.lib %LIBRARY_LIB%
+if errorlevel 1 exit 1
+

--- a/recipe/bld_static.bat
+++ b/recipe/bld_static.bat
@@ -1,3 +1,8 @@
+:: Build
+set PLATFORM=x64
+set CONFIGURATION=Release
+set VSPROJ_DIR=%SRC_DIR%\visual\VS2017
+set BUILD_DIR=%VSPROJ_DIR%\bin\%PLATFORM%_%CONFIGURATION%
 COPY %BUILD_DIR%\liblz4_static.lib %LIBRARY_LIB%
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,3 +30,4 @@ fi
 
 # Install
 make install PREFIX=${PREFIX}
+rm ${PREFIX}/lib/liblz4.a

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cp lib/liblz4.a ${PREFIX}/lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     # - patches/0002-Do-not-build-tests-binaries-on-VS-project.patch  # [win]
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,6 @@
 {% set pkg_name = "lz4-c" %}
-{% set author = "lz4" %}
 {% set name = "lz4" %}
 {% set version = "1.9.2" %}
-{% set sha256sum = "658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc" %}
-{% set build = 2 %}
 
 package:
   name: {{ pkg_name }}
@@ -11,8 +8,8 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/{{ author }}/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: {{ sha256sum }}
+  url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc
   patches:
     # Split into 2 patches due to a bug in conda-build
     # - patches/0001-Add-WindowsTargetPlatformVersion-of-10.0-and-lz4-exe.patch
@@ -22,11 +19,7 @@ source:
     # - patches/0002-Do-not-build-tests-binaries-on-VS-project.patch  # [win]
 
 build:
-  skip: true  # [win and vc<14]
-  number: {{ build }}
-  # https://abi-laboratory.pro/index.php?view=timeline&l=lz4
-  run_exports:
-    - {{ pin_subpackage(pkg_name, max_pin='x.x') }}
+  number: 2
 
 requirements:
   build:
@@ -39,34 +32,49 @@ requirements:
   host:
   run:
 
-test:
-  requires:
-    - pkg-config  # [unix]
+outputs:
+  - name: lz4-c
+    build:
+      # https://abi-laboratory.pro/index.php?view=timeline&l=lz4
+      run_exports:
+        - {{ pin_subpackage(pkg_name, max_pin='x.x') }}
+    test:
+      requires:
+        - pkg-config  # [unix]
 
-  commands:
-    - lz4 -h
-    - lz4c -h    # [unix]
-    - lz4cat -h  # [unix]
-    - unlz4 -h   # [unix]
+      commands:
+        - lz4 -h
+        - lz4c -h    # [unix]
+        - lz4cat -h  # [unix]
+        - unlz4 -h   # [unix]
 
-    - test -f ${PREFIX}/include/lz4.h       # [unix]
-    - test -f ${PREFIX}/include/lz4hc.h     # [unix]
-    - test -f ${PREFIX}/include/lz4frame.h  # [unix]
+        - test -f ${PREFIX}/include/lz4.h       # [unix]
+        - test -f ${PREFIX}/include/lz4hc.h     # [unix]
+        - test -f ${PREFIX}/include/lz4frame.h  # [unix]
 
-    - if not exist %LIBRARY_INC%\\lz4.h exit 1       # [win]
-    - if not exist %LIBRARY_INC%\\lz4hc.h exit 1     # [win]
-    - if not exist %LIBRARY_INC%\\lz4frame.h exit 1  # [win]
+        - if not exist %LIBRARY_INC%\\lz4.h exit 1       # [win]
+        - if not exist %LIBRARY_INC%\\lz4hc.h exit 1     # [win]
+        - if not exist %LIBRARY_INC%\\lz4frame.h exit 1  # [win]
 
-    - test -f ${PREFIX}/lib/liblz4.a      # [unix]
-    - test -f ${PREFIX}/lib/liblz4.dylib  # [osx]
-    - test -f ${PREFIX}/lib/liblz4.so     # [linux]
+        - test ! -f ${PREFIX}/lib/liblz4.a      # [unix]
+        - test -f ${PREFIX}/lib/liblz4.dylib  # [osx]
+        - test -f ${PREFIX}/lib/liblz4.so     # [linux]
 
-    - if not exist %LIBRARY_BIN%\\liblz4.dll exit 1         # [win]
-    - if not exist %LIBRARY_LIB%\\liblz4.lib exit 1         # [win]
-    - if not exist %LIBRARY_LIB%\\liblz4_static.lib exit 1  # [win]
+        - if not exist %LIBRARY_BIN%\\liblz4.dll exit 1         # [win]
+        - if not exist %LIBRARY_LIB%\\liblz4.lib exit 1         # [win]
+        - if exist %LIBRARY_LIB%\\liblz4_static.lib exit 1  # [win]
 
-    - test -f ${PREFIX}/lib/pkgconfig/liblz4.pc  # [unix]
-    - pkg-config --cflags --libs liblz4          # [unix]
+        - test -f ${PREFIX}/lib/pkgconfig/liblz4.pc  # [unix]
+        - pkg-config --cflags --libs liblz4          # [unix]
+
+  - name: lz4-c-static
+    script: build_static.sh  # [unix]
+    script: bld_static.bat  # [win]
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/liblz4.a      # [unix]
+        - if not exist %LIBRARY_LIB%\\liblz4_static.lib exit 1  # [win]
+
 
 about:
   home: https://www.lz4.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,6 +68,8 @@ outputs:
         - pkg-config --cflags --libs liblz4          # [unix]
 
   - name: lz4-c-static
+    build:
+      activate_in_script: True
     script: build_static.sh  # [unix]
     script: bld_static.bat  # [win]
     test:


### PR DESCRIPTION
This removes the static libraries from the main package according to [CFEP-18](https://github.com/conda-forge/cfep/pull/34). This might break some downstream builds but this is intended and we should fix the downstream builds to use the shared libraries before adding an output here.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
